### PR TITLE
:rocket: Set up Maven package hosting on GitHub

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,45 @@
+name: Publish Maven Package
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+  test:
+    runs-on: ubuntu-latest
+    depends-on: setup
+
+    steps:
+      - name: Run Tests with Maven
+        run: mvn --batch-mode --update-snapshots clean test -s $GITHUB_WORKSPACE/settings.xml
+
+  package:
+    runs-on: ubuntu-latest
+    depends-on: test
+
+    steps:
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -20,5 +20,13 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
       
+      - name: Maven Settings
+        uses: s4u/maven-settings-action@v2
+        with:
+          servers: '[{"id": "github", "username": "penguineer", "password": "${GITHUB_TOKEN_REF}"}]'
+          githubServer: false
+
       - name: Run Tests with Maven
         run: mvn --batch-mode --update-snapshots clean test
+        env:
+          GITHUB_TOKEN_REF: ${{ secrets.GH_MAVEN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,31 +5,60 @@
 
 ## Deployment
 
-### Including the library
+### Including the library from GitHub
 
-The library can be included with [jitpack](https://jitpack.io/) with two additions to the project's POM file. 
+The library is hosted on GitHub and access is set up for projects using it.
 
-Adding the jitpack repository:
+GitHub packages require authentication. Please refer to 
+[Working with the Apache Maven registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+for the proper setup.
+
+In the POM.xml, two sections must be included.
+
+The GitHub repository:
 ```xml
-<repositories>
-  <repository>
-    <id>jitpack.io</id>
-    <url>https://jitpack.io</url>
-  </repository>
-</repositories>
+  <repositories>
+    <!-- link to maven central here -->
+    <repository>
+      <id>github</id>
+      <name>GitHub penguineer Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/penguineer/maven-packages</url>
+    </repository>
+  </repositories>
 ```
 
-Adding the library:
+The dependency:
 ```xml
 <dependency>
-  <groupId>com.github.penguineer</groupId>
-  <artifactId>cleanURI-common</artifactId>
-  <version>main-HEAD</version>
+    <groupId>com.penguineering.cleanuri</groupId>
+    <artifactId>common</artifactId>
+    <version>version</version>
+    <scope>compile</scope>
 </dependency>
 ```
 Replace the `version` tag with the desired release.
 
-Please refer to the [jitpack documentation](https://jitpack.io/) on using alternative build systems.
+
+This method is used by the GitHub actions that create Docker Images of the various cleanURI components.
+
+### Including the library from Local installation
+
+You can check out the library as a local working copy and then build and install with:
+```bash
+mvn build package
+mnv install
+```
+
+Only the dependency needs to be added to your POM:
+```xml
+<dependency>
+    <groupId>com.penguineering.cleanuri</groupId>
+    <artifactId>common</artifactId>
+    <version>version</version>
+    <scope>compile</scope>
+</dependency>
+```
+Replace the `version` tag with the desired release.
 
 ### Development
 
@@ -38,6 +67,8 @@ This project uses the [Micronaut Framework](https://micronaut.io/).
 Version numbers are determined with [jgitver](https://jgitver.github.io/).
 Please check your [IDE settings](https://jgitver.github.io/#_ides_usage) to avoid problems, as there are still some unresolved issues.
 If you encounter a project version `0` there is an issue with the jgitver generator.
+
+If access to the GitHub packages repository is not available, please check *Including the library from Local installation* on how to make the artifact available locally. 
 
 
 ## Maintainers

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,14 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub penguineer Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/penguineer/maven-packages</url>
+    </repository>
+  </distributionManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.micronaut</groupId>
@@ -64,6 +72,11 @@
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.rabbitmq</groupId>
+      <artifactId>micronaut-rabbitmq</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Workflows are based on https://maurocanuto.medium.com/using-github-private-packages-and-maven-in-github-actions-c9e2ea69e2bc