### PR TITLE
:sparkles: Add the extraction task emitter

### DIFF
--- a/src/main/java/com/penguineering/cleanuri/common/amqp/ExtractionTaskEmitter.java
+++ b/src/main/java/com/penguineering/cleanuri/common/amqp/ExtractionTaskEmitter.java
@@ -1,0 +1,16 @@
+package com.penguineering.cleanuri.common.amqp;
+
+import com.penguineering.cleanuri.common.message.ExtractionTask;
+import io.micronaut.rabbitmq.annotation.Binding;
+import io.micronaut.rabbitmq.annotation.RabbitClient;
+import io.micronaut.rabbitmq.annotation.RabbitProperty;
+
+@RabbitClient
+public interface ExtractionTaskEmitter {
+    @SuppressWarnings("unused")
+    @RabbitProperty(name = "contentType", value = "application/json")
+    void send(@Binding String destination,
+              @RabbitProperty("correlationId") String correlationId,
+              @RabbitProperty("replyTo") String replyTo,
+              ExtractionTask task);
+}


### PR DESCRIPTION
Emit an extraction task to a specified task queue. This is a central
part of task handling and result forwarding in the cleanURI eco-system.