### PR TITLE
:art: Switch to ISO8601 timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.micronaut.rabbitmq</groupId>
       <artifactId>micronaut-rabbitmq</artifactId>
       <scope>compile</scope>

--- a/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
+++ b/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
@@ -1,9 +1,10 @@
 package com.penguineering.cleanuri.common.message;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Bean;
 
-import java.time.Clock;
+import java.time.Instant;
 
 @Bean
 public class MetaData {
@@ -18,14 +19,14 @@ public class MetaData {
             return new Builder(value);
         }
         private final String value;
-        private long timestamp;
+        private Instant timestamp;
 
         Builder(String value) {
             this.value = value;
-            this.timestamp = Clock.systemUTC().millis();
+            this.timestamp = Instant.now();
         }
 
-        public Builder setTimestamp(long timestamp) {
+        public Builder setTimestamp(Instant timestamp) {
             this.timestamp = timestamp;
             return this;
         }
@@ -37,10 +38,11 @@ public class MetaData {
 
 
     private final String value;
-    private final long timestamp;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private final Instant timestamp;
 
     MetaData(@JsonProperty(value = "value", required = true) String value,
-              @JsonProperty(value = "timestamp", required = true) long timestamp) {
+              @JsonProperty(value = "timestamp", required = true) Instant timestamp) {
         if (value == null || value.isBlank())
             throw new IllegalArgumentException("Metadata value must not be null or blank!");
         this.value = value;
@@ -51,7 +53,7 @@ public class MetaData {
         return value;
     }
 
-    public long getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 }


### PR DESCRIPTION
Instead of a Unix timestamp (Epoch) use ISO8601-compliant timestamps for meta-data annotations.