### PR TITLE
Add Bean and Factory to inject list of Site implementations from the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
 
   <repositories>
     <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+    <repository>
       <id>central</id>
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
@@ -44,6 +48,12 @@
   </distributionManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>com.github.penguineer</groupId>
+      <artifactId>cleanURI-site</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-inject</artifactId>

--- a/src/main/java/com/penguineering/cleanuri/common/sites/SiteFactory.java
+++ b/src/main/java/com/penguineering/cleanuri/common/sites/SiteFactory.java
@@ -1,0 +1,35 @@
+package com.penguineering.cleanuri.common.sites;
+
+import com.penguineering.cleanuri.site.Site;
+import com.penguineering.cleanuri.site.SiteLoader;
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Factory class responsible for providing site implementations discovered on the classpath.
+ * <p>
+ * This class uses the {@link SiteLoader} to find and load all available implementations of the {@link Site} interface.
+ * The loaded sites are then logged and returned as a list.
+ */
+@Factory
+public class SiteFactory {
+    private final SiteLoader siteModuleLoader;
+    private static final Logger logger = LoggerFactory.getLogger(SiteFactory.class);
+
+    @Inject
+    public SiteFactory(SiteLoader siteModuleLoader) {
+        this.siteModuleLoader = siteModuleLoader;
+    }
+
+    @Singleton
+    public List<Site> sites() {
+        List<Site> sites = siteModuleLoader.findSitesOnClasspath();
+        sites.forEach(site -> logger.info("Discovered site: " + site.getSiteDescriptor().getLabel()));
+        return sites;
+    }
+}

--- a/src/main/java/com/penguineering/cleanuri/common/sites/SiteLoaderBean.java
+++ b/src/main/java/com/penguineering/cleanuri/common/sites/SiteLoaderBean.java
@@ -1,0 +1,27 @@
+package com.penguineering.cleanuri.common.sites;
+
+import com.penguineering.cleanuri.site.SiteLoader;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+/**
+ * Factory for creating a singleton {@link SiteLoader} bean.
+ * This class is necessary as {@link SiteLoader} is independent of the Micronaut injection framework.
+ * By defining {@link SiteLoader} as a singleton bean, we ensure one instance is shared across the application.
+ */
+@Factory
+public class SiteLoaderBean {
+
+    /**
+     * Provides a singleton {@link SiteLoader} bean.
+     * This method creates a new {@link SiteLoader} instance, managed as a singleton bean by the application context.
+     *
+     * @return a new {@link SiteLoader} instance
+     */
+    @Bean
+    @Singleton
+    public SiteLoader siteModuleLoader() {
+        return new SiteLoader();
+    }
+}


### PR DESCRIPTION
This factory allows to discover any Site implementations that have been put on the classpath, meaning that the actual implementations must not support Micronaut injections and can be added after packaging.