### PR TITLE
:arrow_up: Update to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <packaging>jar</packaging>
-    <jdk.version>17</jdk.version>
-    <release.version>17</release.version>
+    <jdk.version>21</jdk.version>
+    <release.version>21</release.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This pull request includes a small but significant change to the `pom.xml` file. The change updates the Java version used in the project from 17 to 21.

Changes in `pom.xml`:

* Updated the `maven.compiler.source` and `maven.compiler.target` properties to use Java version 21 instead of 17.
* Updated the `jdk.version` and `release.version` properties to 21.