### PR TITLE
:arrow_up: Fix jitpack settings for Java 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,5 +2,5 @@
 #  - openjdk17
 before_install:
   - sdk update
-  - sdk install java 17.0.3-tem
-  - sdk use java 17.0.3-tem
+  - sdk install java 21.0.6-tem
+  - sdk use java 21.0.6-tem


### PR DESCRIPTION
This pull request includes an update to the `jitpack.yml` file to use a newer version of Java. The change updates the Java version from 17.0.3-tem to 21.0.6-tem.

* [`jitpack.yml`](diffhunk://#diff-1604193a5efbe3735c6ab8b44601ad6e42df52f6834bcc155650e3eef5b3fa94L5-R6): Updated Java version from 17.0.3-tem to 21.0.6-tem.