### PR TITLE
:arrow_up: Bump cleanuri-site dependency to 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-site</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request includes a version update for the `cleanURI-site` dependency in the `pom.xml` file.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L54-R54): Updated `cleanURI-site` dependency version from `0.1.0` to `0.2.1`.