### PR TITLE
Fix serialization for Micronaut 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-jackson-databind</artifactId>
+      <groupId>io.micronaut.serde</groupId>
+      <artifactId>micronaut-serde-jackson</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/penguineering/cleanuri/common/message/ExtractionRequest.java
+++ b/src/main/java/com/penguineering/cleanuri/common/message/ExtractionRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.net.URI;
 import java.time.Duration;
@@ -12,6 +13,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Bean
+@Serdeable
 public class ExtractionRequest {
     public static class Builder {
         public static Builder withURI(URI uri) {
@@ -46,12 +48,10 @@ public class ExtractionRequest {
         }
     }
 
-    @JsonProperty("uri")
     private final URI uri;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final Set<MetaData.Fields> fields;
 
-    @JsonProperty("age-limit")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private final Duration ageLimit;
@@ -66,14 +66,17 @@ public class ExtractionRequest {
         this.ageLimit = ageLimit;
     }
 
+    @JsonProperty("uri")
     public URI getURI() {
         return uri;
     }
 
+    @JsonProperty("fields")
     public Set<MetaData.Fields> getFields() {
         return fields == null ? Collections.emptySet() : Collections.unmodifiableSet(fields);
     }
 
+    @JsonProperty("age-limit")
     public Duration getAgeLimit() {
         return ageLimit;
     }

--- a/src/main/java/com/penguineering/cleanuri/common/message/ExtractionTask.java
+++ b/src/main/java/com/penguineering/cleanuri/common/message/ExtractionTask.java
@@ -3,11 +3,13 @@ package com.penguineering.cleanuri.common.message;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.net.URI;
 import java.util.*;
 
 @Bean
+@Serdeable
 public class ExtractionTask {
     public static class Builder {
         public static Builder withRequest(ExtractionRequest request) {
@@ -66,7 +68,6 @@ public class ExtractionTask {
 
     private final ExtractionRequest request;
 
-    @JsonProperty("canonized-uri")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final URI canonizedURI;
 
@@ -89,18 +90,22 @@ public class ExtractionTask {
         this.errors = errors;
     }
 
+    @JsonProperty("request")
     public ExtractionRequest getRequest() {
         return request;
     }
 
+    @JsonProperty("canonized-uri")
     public URI getCanonizedURI() {
         return canonizedURI;
     }
 
+    @JsonProperty("meta")
     public Map<MetaData.Fields, MetaData> getMeta() {
         return meta == null ? Collections.emptyMap() : Collections.unmodifiableMap(meta);
     }
 
+    @JsonProperty("errors")
     public List<String> getErrors() {
         return errors == null ? Collections.emptyList() : Collections.unmodifiableList(errors);
     }

--- a/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
+++ b/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
@@ -3,10 +3,12 @@ package com.penguineering.cleanuri.common.message;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.time.Instant;
 
 @Bean
+@Serdeable
 public class MetaData {
     public enum Fields {
         @JsonProperty("id") ID,
@@ -49,10 +51,12 @@ public class MetaData {
         this.timestamp = timestamp;
     }
 
+    @JsonProperty("value")
     public String getValue() {
         return value;
     }
 
+    @JsonProperty("timestamp")
     public Instant getTimestamp() {
         return timestamp;
     }


### PR DESCRIPTION
This pull request updates the serialization mechanism for several classes in the project by transitioning from `micronaut-jackson-databind` to `micronaut-serde-jackson`. It also refactors the serialization-related annotations to align with the new library, ensuring compatibility and improving maintainability.

### Dependency Update:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L76-R77): Replaced the `micronaut-jackson-databind` dependency with `micronaut-serde-jackson` to leverage Micronaut's new serialization library.

### Serialization Enhancements:
* **`ExtractionRequest` class**:
  - Added the `@Serdeable` annotation to enable compatibility with the new serialization library. [[1]](diffhunk://#diff-6a17640bfb871394d2129f394248e4f72751f292226fe2b8493d97630bcbd0fbR7) [[2]](diffhunk://#diff-6a17640bfb871394d2129f394248e4f72751f292226fe2b8493d97630bcbd0fbR16)
  - Moved `@JsonProperty` annotations from fields to getter methods for better encapsulation and alignment with the new serialization approach. [[1]](diffhunk://#diff-6a17640bfb871394d2129f394248e4f72751f292226fe2b8493d97630bcbd0fbL49-L54) [[2]](diffhunk://#diff-6a17640bfb871394d2129f394248e4f72751f292226fe2b8493d97630bcbd0fbR69-R79)
* **`ExtractionTask` class**:
  - Added the `@Serdeable` annotation for serialization compatibility.
  - Moved `@JsonProperty` annotations from fields to getter methods. [[1]](diffhunk://#diff-1432fec1b3323b08983d07912a4cd11e616d06104d558165d8265c41eae516e7L69) [[2]](diffhunk://#diff-1432fec1b3323b08983d07912a4cd11e616d06104d558165d8265c41eae516e7R93-R108)
* **`MetaData` class**:
  - Added the `@Serdeable` annotation to support the new serialization mechanism.
  - Moved `@JsonProperty` annotations from fields to getter methods.