### PR TITLE
Fix that Jackson could not de-serialize its own timestamp

### DIFF
--- a/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
+++ b/src/main/java/com/penguineering/cleanuri/common/message/MetaData.java
@@ -38,7 +38,7 @@ public class MetaData {
 
 
     private final String value;
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @JsonFormat(timezone = "UTC", pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     private final Instant timestamp;
 
     MetaData(@JsonProperty(value = "value", required = true) String value,


### PR DESCRIPTION
This pull request updates the timestamp formatting in the `MetaData` class to include a specific pattern and timezone, because Jackson was not able to decode the precision it created on serialization.

### Changes to timestamp formatting:

* [`src/main/java/com/penguineering/cleanuri/common/message/MetaData.java`](diffhunk://#diff-cebf7941ed77cafa123ae5e9b478d76bb22b877537cf46c4a2c7ee674c75e4b5L41-R41): Updated the `@JsonFormat` annotation for the `timestamp` field to specify the UTC timezone and the pattern `yyyy-MM-dd'T'HH:mm:ss.SSSX`. This ensures that timestamps are consistently formatted and include timezone information.